### PR TITLE
[Swift] style guide - no copyright

### DIFF
--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -941,7 +941,7 @@ if (name == "Hello") {
 
 ## Copyright Statement
 
-Do not include any copyright statements in the source files.
+Do not include any copyright statements in the source files, or any other banner header. Remove any default header provided by Xcode templates.
 
 ## Smiley Face
 

--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -941,30 +941,7 @@ if (name == "Hello") {
 
 ## Copyright Statement
 
-The following copyright statement should be included at the top of every source
-file:
-
-    /**
-     * Copyright (c) 2016 Razeware LLC
-     *
-     * Permission is hereby granted, free of charge, to any person obtaining a copy
-     * of this software and associated documentation files (the "Software"), to deal
-     * in the Software without restriction, including without limitation the rights
-     * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-     * copies of the Software, and to permit persons to whom the Software is
-     * furnished to do so, subject to the following conditions:
-     *
-     * The above copyright notice and this permission notice shall be included in
-     * all copies or substantial portions of the Software.
-     *
-     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-     * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-     * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-     * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-     * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-     * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-     * THE SOFTWARE.
-     */
+We do not include any copyright statements in the source files.
 
 ## Smiley Face
 

--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -941,7 +941,7 @@ if (name == "Hello") {
 
 ## Copyright Statement
 
-We do not include any copyright statements in the source files.
+Do not include any copyright statements in the source files.
 
 ## Smiley Face
 


### PR DESCRIPTION
**The problem**: the style guide we copied from has a standard copyright statement to be included in all files, but we do not use any.
**The solution**: update the style guide accordingly, specifically mentioning not to include copyright statements.