### PR TITLE
[Swift] style guide - smiley faces

### DIFF
--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -50,7 +50,6 @@ Writing Objective-C? Check out our [Objective-C Style Guide](https://github.com/
 * [Semicolons](#semicolons)
 * [Parentheses](#parentheses)
 * [Copyright Statement](#copyright-statement)
-* [Smiley Face](#smiley-face)
 * [Credits](#credits)
 
 

--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -966,20 +966,6 @@ file:
      * THE SOFTWARE.
      */
 
-## Smiley Face
-
-Smiley faces are a very prominent style feature of the raywenderlich.com site! It is very important to have the correct smile signifying the immense amount of happiness and excitement for the coding topic. The closing square bracket `]` is used because it represents the largest smile able to be captured using ASCII art. A closing parenthesis `)` creates a half-hearted smile, and thus is not preferred.
-
-**Preferred:**
-```
-:]
-```
-
-**Not Preferred:**
-```
-:)
-```
-
 ## Credits
 
 [Ray Fix](https://github.com/rayfix) currently maintains this style guide.


### PR DESCRIPTION
**The problem**: the section on smiley faces is unnecessary, mentions a third party, and frankly is wrong !
`:)` > `:]` but both by are defeated by 😃 

**The solution**: remove it.