### PR TITLE
Opening a discussion on how to clarify the section on reference semantics

### DIFF
--- a/style-guides/swift/README.markdown
+++ b/style-guides/swift/README.markdown
@@ -215,7 +215,7 @@ Use extensions to organize your code into logical blocks of functionality. Each 
 
 ### Protocol Conformance
 
- In particular, when adding protocol conformance to a model, don't add the conformance in an extension. This is to highlight the code smell of using inheritance over delegation. Any time it is possible to create this relationship using delegation, do so.
+ In particular, when adding protocol conformance to a model, prefer adding a separate extension for the protocol methods. This keeps the related methods grouped together with the protocol and can simplify instructions to add a protocol to a class with its associated methods.
 
 **Preferred:**
 ```swift


### PR DESCRIPTION
This PR removes the section on when to use classes and when to use structs as that decision is not a matter of style.

~~This is a strange PR. I'm not yet proposing a patch but, rather, I'm opening up a discussion because I don't have a good idea yet on how to correct what I believe needs correction.~~

~~Please see the diffs, where I make my opening points.~~
