### PR TITLE
QUESTION: Remove force showing line numbers

### DIFF
--- a/ide-settings/intellij/settings/options/editor.xml
+++ b/ide-settings/intellij/settings/options/editor.xml
@@ -4,7 +4,6 @@
     <option name="IS_VIRTUAL_SPACE" value="true" />
     <option name="IS_ENSURE_NEWLINE_AT_EOF" value="true" />
     <option name="QUICK_DOC_ON_MOUSE_OVER_DELAY_MS" value="400" />
-    <option name="ARE_LINE_NUMBERS_SHOWN" value="true" />
     <option name="IS_CAMEL_WORDS" value="true" />
   </component>
   <component name="XmlEditorOptions">


### PR DESCRIPTION
By default line numbers are shown in IntelliJ but I really don't like it. It is ugliness that I don't need on my screen. :)

I don't know if there is a value to force keep it in Novoda style? Do we want everybody to have line numbers? 😄 