### PR TITLE
Issue template for NOS

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,22 @@
-## Problem
+## Issue
 _Briefly describe the issue you are experiencing / feature you would like to see added. Although the following sections are **Optional** the more information you provide, the faster this issue can be addressed._
+
+## Potential Solution [Optional]
+_Explain high level any potential solution to the issue as you see it_
 
 ## Environment [Optional]
 * _Version of the project where the issue occurs_
 * _Real device or emulator_
 * _Mobile platform/Version_
 
-## Potential Solution [Optional]
-_Explain high level any potential solutions to the issue as you see it_
+## Sample Code [Optional]
+_Sample code can be given to aid us understand all issues. In particular, sample code facilitates reproducing bugs, making it that much easier and faster for the issue to be addressed. Samples should be:_
 
-## Code to Reproduce the Issue [Optional]
-_Sample code can be given to aid us understand all issues. In particular, sample code facilitates reproducing the issue, making it that much easier and faster for the issue to be addressed._
+* _**Minimal** - Streamline your example. The more code there is to go through, the harder it is to find the problem._
+
+* _**Complete** - Make sure to include all information necessary to reproduce the problem._
+
+* _**Verifiable** - Ensure that the example actually reproduces the problem._
+
+See [here](https://stackoverflow.com/help/mcve) for more information.
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Problem
-_Briefly describe the issue you are experiencing / feature you would like to see added. Although the following sections are **Optional** the more information you give, the faster we can resolve this issue for you_
+_Briefly describe the issue you are experiencing / feature you would like to see added. Although the following sections are **Optional** the more information you provide, the faster this issue can be addressed._
 
 ## Environment [Optional]
 * _Version of the project where the issue occurs_
@@ -10,4 +10,4 @@ _Briefly describe the issue you are experiencing / feature you would like to see
 _Explain high level any potential solutions to the issue as you see it_
 
 ## Code to Reproduce the Issue [Optional]
-_Sample code can be given to aid us understand all issues. In particular, sample code allows us to reproduce the issue making it that much easier and faster for us to resolve the issue._
+_Sample code can be given to aid us understand all issues. In particular, sample code facilitates reproducing the issue, making it that much easier and faster for the issue to be addressed._

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Problem
+_Briefly describe the issue you are experiencing / feature you would like to see added. Although the following sections are **Optional** the more information you give, the faster we can resolve this issue for you_
+
+## Environment [Optional]
+* _Version of the project where the issue occurs_
+* _Real device or emulator_
+* _Mobile platform/Version_
+
+## Potential Solution [Optional]
+_Explain high level any potential solutions to the issue as you see it_
+
+## Code to Reproduce the Issue [Optional]
+_Sample code can be given to aid us understand all issues. In particular, sample code allows us to reproduce the issue making it that much easier and faster for us to resolve the issue._


### PR DESCRIPTION
## This PR adds
An issue template.

## Considerations and implementation
Opening this mainly for discussion on the important pieces of information that we typically require when someone opens an issue against our open source projects. The plan is for this to be used as a starting point for all NOS projects.  


# Screen Capture

![screen shot 2017-12-01 at 13 07 20](https://user-images.githubusercontent.com/3380092/33484045-992d415e-d698-11e7-82d6-0a987650bc65.png)




### Paired with 
Nobody.
