### PR TITLE
NOS-49/Add static analysis baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.idea
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .DS_Store
-.idea
 *~
+
+# IDEA Ignores
+*.ipr
+*.iws
+.idea/
+.gradle/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/team-props/android-code-quality.gradle
+++ b/team-props/android-code-quality.gradle
@@ -1,0 +1,13 @@
+task clean(type: Delete, dependsOn: subprojects.collect { p -> "$p.name:clean" }) {
+    delete project.buildDir
+}
+
+task check(dependsOn: subprojects.collect { p ->
+    "$p.name:check"
+})
+
+task assemble(dependsOn: subprojects.collect { p ->
+    "$p.name:assemble"
+})
+
+task build(dependsOn: ['assemble', 'check'])

--- a/team-props/lint-rules/config.xml
+++ b/team-props/lint-rules/config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+
+  <issue id="all">
+    <ignore regexp="build/generated/.*" />
+  </issue>
+
+</lint>

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -1,0 +1,36 @@
+apply plugin: 'com.novoda.static-analysis'
+
+staticAnalysis {
+    penalty {
+        maxErrors = 0
+        maxWarnings = 0
+    }
+
+    checkstyle {
+        toolVersion checkstyleVersion
+        exclude project.fileTree('src/test/java')
+        exclude project.fileTree('src/testDebug/java')
+        configFile teamPropsFile('static-analysis/checkstyle-modules.xml')
+        includeVariants { variant -> excludeTestAndRelease(variant) }
+    }
+
+    pmd {
+        toolVersion pmdVersion
+        exclude project.fileTree('src/test/java')
+        exclude project.fileTree('src/testDebug/java')
+
+        ruleSetFiles = rootProject.files('team-props/static-analysis/pmd-rules.xml')
+        ruleSets = []   // Note: this is a workaround to make the <exclude-pattern>s in pmd-rules.xml actually work
+        includeVariants { variant -> excludeTestAndRelease(variant) }
+    }
+
+    findbugs {
+        toolVersion findbugsVersion
+        excludeFilter teamPropsFile('static-analysis/findbugs-excludes.xml')
+        includeVariants { variant -> excludeTestAndRelease(variant) }
+    }
+}
+
+static boolean excludeTestAndRelease(variant) {
+    return !variant.name.toLowerCase().endsWith('test') && !variant.name.toLowerCase().endsWith('release')
+}

--- a/team-props/static-analysis/checkstyle-modules.xml
+++ b/team-props/static-analysis/checkstyle-modules.xml
@@ -1,0 +1,163 @@
+<!DOCTYPE module PUBLIC
+  "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+  "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+  <module name="SuppressionFilter">
+    <property name="file" value="team-props/static-analysis/checkstyle-suppressions.xml" />
+  </module>
+
+  <module name="SuppressWarningsFilter" />
+
+  <!-- Checks whether files end with a new line.                        -->
+  <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+  <module name="NewlineAtEndOfFile" />
+
+  <!-- Checks that property files contain the same keys.         -->
+  <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+  <module name="Translation" />
+
+  <!-- Checks for Size Violations.                    -->
+  <!-- See http://checkstyle.sf.net/config_sizes.html -->
+  <module name="FileLength" />
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+  <module name="FileTabCharacter" />
+
+  <!-- Miscellaneous other checks.                   -->
+  <!-- See http://checkstyle.sf.net/config_misc.html -->
+  <module name="RegexpSingleline">
+    <property name="format" value="\s+$" />
+    <property name="minimum" value="0" />
+    <property name="maximum" value="0" />
+    <property name="message" value="Line has trailing spaces." />
+    <property name="severity" value="info" />
+  </module>
+
+  <module name="TreeWalker">
+
+    <module name="SuppressWarningsHolder" />
+
+    <!-- Suppressions -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat"
+        value="CHECKSTYLE IGNORE\s+(\S+)" />
+      <property name="onCommentFormat"
+        value="CHECKSTYLE END IGNORE\s+(\S+)" />
+      <property name="checkFormat"
+        value="$1" />
+    </module>
+
+    <module name="SuppressWithNearbyCommentFilter">
+      <!-- Syntax is "SUPPRESS CHECKSTYLE name" -->
+      <property name="commentFormat"
+        value="SUPPRESS CHECKSTYLE (\w+)" />
+      <property name="checkFormat"
+        value="$1" />
+      <property name="influenceFormat"
+        value="1" />
+    </module>
+
+    <!-- Checks for Naming Conventions.                  -->
+    <!-- See http://checkstyle.sf.net/config_naming.html -->
+    <module name="ConstantName" />
+    <module name="LocalFinalVariableName" />
+    <module name="LocalVariableName" />
+    <module name="MemberName" />
+    <module name="MethodName" />
+    <module name="PackageName" />
+    <module name="ParameterName" />
+    <module name="StaticVariableName" />
+    <module name="TypeName" />
+
+    <!-- Checks for imports                              -->
+    <!-- See http://checkstyle.sf.net/config_import.html -->
+    <module name="AvoidStarImport">
+      <property name="allowStaticMemberImports" value="true" />
+    </module>
+    <module name="IllegalImport" />
+    <!-- defaults to sun.* packages -->
+    <module name="RedundantImport" />
+    <module name="UnusedImports" />
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+      <!-- what is a good max value? -->
+      <property name="max" value="150" />
+      <!-- ignore lines like "$File: //depot/... $" -->
+      <property name="ignorePattern" value="\$File.*\$" />
+      <property name="severity" value="info" />
+    </module>
+    <module name="MethodLength" />
+    <module name="ParameterNumber" />
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="EmptyForIteratorPad" />
+    <module name="GenericWhitespace" />
+    <module name="MethodParamPad" />
+    <module name="NoWhitespaceAfter" />
+    <module name="NoWhitespaceBefore" />
+    <module name="OperatorWrap" />
+    <module name="ParenPad" />
+    <module name="TypecastParenPad" />
+    <module name="WhitespaceAfter" />
+    <module name="WhitespaceAround" />
+
+    <!-- Modifier Checks                                    -->
+    <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+    <module name="ModifierOrder" />
+    <module name="RedundantModifier" />
+
+    <!-- Checks for blocks. You know, those {}'s         -->
+    <!-- See http://checkstyle.sf.net/config_blocks.html -->
+    <module name="AvoidNestedBlocks" />
+    <module name="EmptyBlock">
+      <property name="option" value="text" />
+    </module>
+    <module name="LeftCurly" />
+    <module name="NeedBraces" />
+    <module name="RightCurly" />
+
+    <!-- Checks for common coding problems               -->
+    <!-- See http://checkstyle.sf.net/config_coding.html -->
+    <module name="EmptyStatement" />
+    <module name="EqualsHashCode" />
+    <module name="HiddenField">
+      <property name="ignoreConstructorParameter" value="true" />
+      <property name="ignoreSetter" value="true" />
+      <property name="severity" value="ignore" />
+    </module>
+    <module name="IllegalInstantiation" />
+    <module name="InnerAssignment" />
+    <module name="MagicNumber">
+      <property name="severity" value="warning" />
+      <property name="ignoreHashCodeMethod" value="true" />
+      <property name="ignoreAnnotation" value="true" />
+    </module>
+    <module name="MissingSwitchDefault" />
+    <module name="SimplifyBooleanExpression" />
+    <module name="SimplifyBooleanReturn" />
+
+    <!-- Checks for class design                         -->
+    <!-- See http://checkstyle.sf.net/config_design.html -->
+    <module name="FinalClass" />
+    <module name="HideUtilityClassConstructor" />
+    <module name="InterfaceIsType" />
+    <module name="VisibilityModifier">
+      <!-- Ignore fields injected by Dagger as it requires at least package private visibility -->
+      <property name="ignoreAnnotationCanonicalNames"
+        value="javax.inject.Inject" />
+    </module>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <module name="ArrayTypeStyle" />
+    <module name="UpperEll" />
+
+  </module>
+
+</module>

--- a/team-props/static-analysis/checkstyle-suppressions.xml
+++ b/team-props/static-analysis/checkstyle-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+  "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions />

--- a/team-props/static-analysis/findbugs-excludes.xml
+++ b/team-props/static-analysis/findbugs-excludes.xml
@@ -1,0 +1,13 @@
+<FindBugsFilter>
+
+  <Match>
+    <Or>
+      <Class name="~.*\.R\$.*" />
+      <Class name="~.*\.R\$.*" />
+      <Class name="~.*Test" />
+      <Class name="~.*Test\$.*" />
+      <Class name="~.*\.Manifest\$.*" />
+    </Or>
+  </Match>
+
+</FindBugsFilter>

--- a/team-props/static-analysis/lint-config.xml
+++ b/team-props/static-analysis/lint-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+
+  <issue id="MissingTranslation" severity="ignore" />
+  <issue id="GoogleAppIndexingWarning" severity="ignore" />
+
+  <issue id="OldTargetApi" severity="informational" />
+
+  <!-- Ignore RtL warnings since the app doesn't support RtL -->
+  <issue id="RtlSymmetry" severity="ignore" />
+  <issue id="RtlHardcoded" severity="ignore" />
+  <issue id="RtlEnabled" severity="ignore" />
+
+  <!-- Lint only flags only missing content descriptions in XML ImageViews but we rarely put content descriptions here -->
+  <issue id="ContentDescription" severity="ignore" />
+
+  <!-- The Google Services JSON plugin generates some API keys even if we don't actually use them -->
+  <issue id="UnusedResources" severity="informational">
+    <ignore path="*generated/res/google-services/*" />
+  </issue>
+
+  <!-- This issue flags the adaptive icons' background drawables too, which must be square and fully opaque -->
+  <issue id="IconLauncherShape" severity="error">
+    <ignore path="*res/mipmap*/ic_launcher_background.png" />
+  </issue>
+
+</lint>

--- a/team-props/static-analysis/pmd-rules.xml
+++ b/team-props/static-analysis/pmd-rules.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  name="Project PMD rules"
+  xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+  xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+  <description>PMD rules for the Project codebase.</description>
+
+  <exclude-pattern>.*\.R\$.*</exclude-pattern>
+  <exclude-pattern>.*Test.*</exclude-pattern>
+
+  <rule ref="rulesets/java/strictexception.xml">
+    <!-- Ignored because of the Callable pattern -->
+    <exclude name="SignatureDeclareThrowsException" />
+  </rule>
+  <rule ref="rulesets/java/typeresolution.xml">
+    <!-- Ignored because of the Callable pattern -->
+    <exclude name="SignatureDeclareThrowsException" />
+  </rule>
+
+  <rule ref="rulesets/java/naming.xml/ShortMethodName">
+    <properties>
+      <property name="xpath">
+        <value>
+          //MethodDeclarator[string-length(@Image) &lt; 2]
+        </value>
+      </property>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/braces.xml" />
+
+  <rule ref="rulesets/java/design.xml">
+    <exclude name="TooFewBranchesForASwitchStatement" />
+    <exclude name="EmptyMethodInAbstractClassShouldBeAbstract" />
+    <exclude name="FieldDeclarationsShouldBeAtStartOfClass" />
+    <exclude name="ConfusingTernary" />
+    <exclude name="AccessorMethodGeneration" />
+  </rule>
+
+  <rule ref="rulesets/java/design.xml/EmptyMethodInAbstractClassShouldBeAbstract">
+    <priority>5</priority>
+  </rule>
+
+  <!-- Suppress ImmutableField check for Api models -->
+  <rule ref="rulesets/java/design.xml/ImmutableField">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//ClassOrInterfaceDeclaration[starts-with(@Image, 'Api')]//FieldDeclaration" />
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/unusedcode.xml" />
+  <rule ref="rulesets/java/logging-java.xml" />
+
+  <rule ref="rulesets/java/strings.xml" />
+
+  <!-- Suppress AvoidDuplicateLiterals check for annotations -->
+  <rule ref="rulesets/java/strings.xml/AvoidDuplicateLiterals">
+    <properties>
+      <property name="skipAnnotations" value="true" />
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/migrating.xml" />
+  <rule ref="rulesets/java/optimizations.xml">
+    <exclude name="LocalVariableCouldBeFinal" />
+    <exclude name="MethodArgumentCouldBeFinal" />
+    <exclude name="AvoidInstantiatingObjectsInLoops" />
+  </rule>
+  <rule ref="rulesets/java/basic.xml" />
+  <rule ref="rulesets/java/sunsecure.xml" />
+  <rule ref="rulesets/java/coupling.xml">
+    <exclude name="LoosePackageCoupling" />
+    <!-- LawOfDemeter seems to be bugged -->
+    <exclude name="LawOfDemeter" />
+  </rule>
+
+  <rule ref="rulesets/java/imports.xml">
+    <exclude name="TooManyStaticImports" />
+  </rule>
+
+  <rule ref="rulesets/java/junit.xml" />
+  <rule ref="rulesets/java/naming.xml">
+    <exclude name="AbstractNaming" />
+    <exclude name="LongVariable" />
+    <exclude name="ShortVariable" />
+    <exclude name="ShortClassName" />
+    <exclude name="AvoidFieldNameMatchingMethodName" />
+  </rule>
+
+  <rule ref="rulesets/java/codesize.xml">
+    <exclude name="TooManyMethods" />
+    <exclude name="TooManyFields" />
+  </rule>
+
+  <!-- Suppress ExcessiveParameterList check for Api models ctors and factory methods -->
+  <rule ref="rulesets/java/codesize.xml/ExcessiveParameterList">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//ClassOrInterfaceDeclaration[starts-with(@Image, 'Api')]//MethodDeclaration[@Static = 'true' and @Private = 'false'] | //ClassOrInterfaceDeclaration[starts-with(@Image, 'Api')]//ConstructorDeclaration" />
+    </properties>
+  </rule>
+
+  <!-- Suppress CyclomaticComplexity check for equals and hashCode -->
+  <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//MethodDeclarator[@Image='equals' or @Image='hashCode']" />
+    </properties>
+  </rule>
+
+  <!-- Suppress ModifiedCyclomaticComplexity check for equals and hashCode -->
+  <rule ref="rulesets/java/codesize.xml/ModifiedCyclomaticComplexity">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//MethodDeclarator[@Image='equals' or @Image='hashCode']" />
+    </properties>
+  </rule>
+
+  <!-- Suppress StdCyclomaticComplexity check for equals and hashCode -->
+  <rule ref="rulesets/java/codesize.xml/StdCyclomaticComplexity">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//MethodDeclarator[@Image='equals' or @Image='hashCode']" />
+    </properties>
+  </rule>
+
+  <!-- Suppress NPathComplexity check for equals and hashCode -->
+  <rule ref="rulesets/java/codesize.xml/NPathComplexity">
+    <properties>
+      <property name="violationSuppressXPath"
+        value="//MethodDeclarator[@Image='equals' or @Image='hashCode']" />
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/java/finalizers.xml" />
+  <rule ref="rulesets/java/logging-jakarta-commons.xml" />
+  <rule ref="rulesets/java/clone.xml" />
+  <rule ref="rulesets/java/android.xml" />
+
+</ruleset>


### PR DESCRIPTION
Tracked by #49 Add static analysis baseline

## This PR adds
A static analysis baseline that can be used for NOS projects where they require this flavour of static analysis.

## Considerations and implementation
This is a clone of `team-props` that has been used for a number of projects. It might be worth creating modules to contain demos for `static analysis` and `release` process. Especially where these differ between Android and other implementations. I'd say this is a good first step anyway.


### Paired with 
Nobody.
