### PR TITLE
[PT-570] Add CI script including prb task

### DIFF
--- a/scaffolding/README.md
+++ b/scaffolding/README.md
@@ -43,8 +43,10 @@ towards Java projects. It supports running Checkstyle, Findbugs, PMD, Androint L
  5. Add this statement at the bottom of the root `build.gradle` file:
     ```gradle
     apply from: teamPropsFile('android-code-quality.gradle')
+    apply from: teamPropsFile('ci.gradle')
     ```
- 6. Add this closure to the root `build.gradle` file:
+ 6. Configure the `prb` task from the `team-props/static-analysis.gradle` file according to your needs and trigger it from jenkins.
+ 7. Add this closure to the root `build.gradle` file:
     ```gradle
     ext {
         checkstyleVersion = '8.8'
@@ -53,8 +55,8 @@ towards Java projects. It supports running Checkstyle, Findbugs, PMD, Androint L
     }
     ```
     Don't forget to check if there's newer versions of the tools; these are the most recent at the time of writing.
- 7. Configure the static analysis settings from the `team-props/static-analysis.gradle` file.
- 8. Configure detekt (optional)
+ 8. Configure the static analysis settings from the `team-props/static-analysis.gradle` file.
+ 9. Configure detekt (optional)
 
     In case you would like to use [detekt](https://github.com/arturbosch/detekt) to analyse your kotlin code, add the following section to the `team-props/static-analysis.gradle` file:
 

--- a/scaffolding/README.md
+++ b/scaffolding/README.md
@@ -42,10 +42,9 @@ towards Java projects. It supports running Checkstyle, Findbugs, PMD, Androint L
     ```
  5. Add this statement at the bottom of the root `build.gradle` file:
     ```gradle
-    apply from: teamPropsFile('android-code-quality.gradle')
-    apply from: teamPropsFile('ci.gradle')
+    apply from: teamPropsFile('scaffolding.gradle')
     ```
- 6. Configure the `prb` task from the `team-props/static-analysis.gradle` file according to your needs and trigger it from jenkins.
+ 6. Configure the `prb` task from the `team-props/ci.gradle` file according to your needs and trigger it from jenkins.
  7. Add this closure to the root `build.gradle` file:
     ```gradle
     ext {

--- a/scaffolding/team-props/ci.gradle
+++ b/scaffolding/team-props/ci.gradle
@@ -1,0 +1,1 @@
+task prb(dependsOn: check)

--- a/scaffolding/team-props/ci.gradle
+++ b/scaffolding/team-props/ci.gradle
@@ -1,3 +1,1 @@
-task prb(dependsOn: subprojects.collect { p ->
-    "$p.name:check"
-})
+task prb(dependsOn: check)

--- a/scaffolding/team-props/ci.gradle
+++ b/scaffolding/team-props/ci.gradle
@@ -1,1 +1,3 @@
-task prb(dependsOn: check)
+task prb(dependsOn: subprojects.collect { p ->
+    "$p.name:check"
+})

--- a/scaffolding/team-props/scaffolding.gradle
+++ b/scaffolding/team-props/scaffolding.gradle
@@ -1,0 +1,2 @@
+apply from: teamPropsFile('ci.gradle')
+apply from: teamPropsFile('android-code-quality.gradle')

--- a/scaffolding/team-props/scaffolding.gradle
+++ b/scaffolding/team-props/scaffolding.gradle
@@ -1,2 +1,2 @@
-apply from: teamPropsFile('ci.gradle')
 apply from: teamPropsFile('android-code-quality.gradle')
+apply from: teamPropsFile('ci.gradle')


### PR DESCRIPTION
Tracked by [PT-570](https://novoda.atlassian.net/browse/PT-570)

## This PR adds

We want to create jenkins templates for jobs like `prb` etc. but don't want to loose flexibility of customising the work that needs to be done for each project. In order to achieve this, this PR adds `ci.gradle` to the novoda scaffolding including updated instructions to include it into the build. 

This will allow each team to customise their `prb` build and put that configuration under source control. In similar fashion we could add tasks for other jobs like `release` etc.

I also created a [jenkins prb template](https://ci.novoda.com/view/Templates/job/android-prb-template/configure) that triggers this task and updated the [wiki](https://github.com/novoda/base/wiki/Setting-up-CI-Pull-Requests-Builder).

## Considerations and implementation

- created `ci.gradle` which defines a `prb` task that runs `check`