### PR TITLE
Add main job to scaffolding

### DIFF
--- a/scaffolding/team-props/ci.gradle
+++ b/scaffolding/team-props/ci.gradle
@@ -1,1 +1,4 @@
 task prb(dependsOn: check)
+
+// modify the main job according to your needs, e.g. to run unit and integration tests
+task main(dependsOn: check)


### PR DESCRIPTION
Tracked by [PT-570](https://novoda.atlassian.net/browse/PT-570)

## This PR adds

This PR adds a `main` task to the scaffolding. 
This job can be now easily configured from the project itself.

References:
- [jenkins template](https://ci.novoda.com/view/Templates/job/android-main-template/)
- [wiki documentation](https://github.com/novoda/base/wiki/Setting-up-Main-Android-CI-Job)
